### PR TITLE
Added support for converting VectorFst to ConstFst to ffi/python lib

### DIFF
--- a/rustfst-ffi/src/fst/const_fst.rs
+++ b/rustfst-ffi/src/fst/const_fst.rs
@@ -149,3 +149,21 @@ pub unsafe extern "C" fn const_fst_display(
         Ok(())
     })
 }
+
+/// # Safety
+///
+/// The pointers should be valid.
+#[no_mangle]
+pub unsafe fn const_fst_from_vec_fst(
+    vec_fst_prt: *const CFst,
+    const_fst_ptr: *mut *const CFst,
+) -> RUSTFST_FFI_RESULT {
+    wrap(|| {
+        let fst = get!(CFst, vec_fst_prt);
+        let vec_fst = as_fst!(VectorFst<TropicalWeight>, fst);
+        let const_fst = ConstFst::<TropicalWeight>::from(vec_fst);
+        let raw_pointer = CFst(const_fst).into_raw_pointer();
+        unsafe { *const_fst_ptr = raw_pointer };
+        Ok(())
+    })
+}

--- a/rustfst-ffi/src/fst/const_fst.rs
+++ b/rustfst-ffi/src/fst/const_fst.rs
@@ -154,15 +154,15 @@ pub unsafe extern "C" fn const_fst_display(
 ///
 /// The pointers should be valid.
 #[no_mangle]
-pub unsafe fn const_fst_from_vec_fst(
+pub unsafe extern "C" fn const_fst_from_vec_fst(
     vec_fst_prt: *const CFst,
     const_fst_ptr: *mut *const CFst,
 ) -> RUSTFST_FFI_RESULT {
     wrap(|| {
         let fst = get!(CFst, vec_fst_prt);
         let vec_fst = as_fst!(VectorFst<TropicalWeight>, fst);
-        let const_fst = ConstFst::<TropicalWeight>::from(vec_fst);
-        let raw_pointer = CFst(const_fst).into_raw_pointer();
+        let const_fst = ConstFst::from(vec_fst.clone());
+        let raw_pointer = CFst(Box::new(const_fst)).into_raw_pointer();
         unsafe { *const_fst_ptr = raw_pointer };
         Ok(())
     })

--- a/rustfst-python/pyproject.toml
+++ b/rustfst-python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=62.1<63",
-    "setuptools_rust>=1.3<1.4",
-    "wheel>=0.34<0.35",
+    "setuptools>=62.1,<63",
+    "setuptools_rust>=1.3,<1.4",
+    "wheel>=0.34,<0.35",
 ]

--- a/rustfst-python/rustfst/fst/const_fst.py
+++ b/rustfst-python/rustfst/fst/const_fst.py
@@ -6,6 +6,7 @@ from rustfst.ffi_utils import (
 )
 
 from rustfst.fst import Fst
+from rustfst.fst.vector_fst import VectorFst
 from rustfst.symbol_table import SymbolTable
 from rustfst.drawing_config import DrawingConfig
 from typing import Optional, Union
@@ -104,6 +105,24 @@ class ConstFst(Fst):
         check_ffi_error(ret_code, err_msg)
 
         return cls(ptr=fst)
+
+    @classmethod
+    def from_vector_fst(cls, fst: VectorFst) -> ConstFst:
+        """
+        Converts a given `VectorFst` to `ConstFst`
+        Args:
+          fst: The `VectorFst` that should be converted
+        Returns:
+          A `ConstFst`
+        Raises:
+          ValueError: Conversion failed
+        """
+        const_fst = ctypes.pointer(ctypes.c_void_p())
+        ret_code = lib.const_fst_from_vec_fst(fst.ptr, ctypes.byref(const_fst))
+        err_msg = f"Failed to convert VectorFST to ConstFST"
+        check_ffi_error(ret_code, err_msg)
+
+        return cls(ptr=const_fst)
 
     def write(self, filename: Union[str, Path]):
         """

--- a/rustfst-python/rustfst/fst/const_fst.py
+++ b/rustfst-python/rustfst/fst/const_fst.py
@@ -119,7 +119,7 @@ class ConstFst(Fst):
         """
         const_fst = ctypes.pointer(ctypes.c_void_p())
         ret_code = lib.const_fst_from_vec_fst(fst.ptr, ctypes.byref(const_fst))
-        err_msg = f"Failed to convert VectorFST to ConstFST"
+        err_msg = "Failed to convert VectorFST to ConstFST"
         check_ffi_error(ret_code, err_msg)
 
         return cls(ptr=const_fst)

--- a/rustfst-python/tests/test_fst.py
+++ b/rustfst-python/tests/test_fst.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from rustfst import VectorFst, Tr, SymbolTable
+from rustfst import VectorFst, Tr, SymbolTable, ConstFst
 import pytest
 from tempfile import NamedTemporaryFile
 
@@ -353,3 +353,16 @@ def test_fst_relabel_tables():
     assert fst_3 == fst_ref
     assert fst_3.input_symbols() == new_isymt
     assert fst_3.output_symbols() == new_osymt
+
+
+def test_const_fst_from_vector_fst():
+    fst = VectorFst()
+    s1 = fst.add_state()
+    s2 = fst.add_state()
+    fst.add_tr(s1, Tr(1, 2, weight_one(), s2))
+    fst.set_start(s1)
+    fst.set_final(s2)
+
+    const_fst = ConstFst.from_vector_fst(fst)
+
+    assert const_fst.num_trs(const_fst.start()) == 1


### PR DESCRIPTION
Added the `from_vector_fst` method to the python class `ConstFst`, which allows for converting a `VectorFst` to `ConstFst`.