### PR TITLE
fix: make Python algorithms consistently return a VectorFst

### DIFF
--- a/rustfst-python/rustfst/algorithms/optimize.py
+++ b/rustfst-python/rustfst/algorithms/optimize.py
@@ -10,7 +10,7 @@ from rustfst.ffi_utils import (
 from rustfst.fst.vector_fst import VectorFst
 
 
-def optimize(fst: VectorFst):
+def optimize(fst: VectorFst) -> VectorFst:
     """
     Optimize an fst in-place
     Args:
@@ -19,9 +19,10 @@ def optimize(fst: VectorFst):
     ret_code = lib.fst_optimize(fst.ptr)
     err_msg = "Error during optimize"
     check_ffi_error(ret_code, err_msg)
+    return fst
 
 
-def optimize_in_log(fst: VectorFst):
+def optimize_in_log(fst: VectorFst) -> VectorFst:
     """
     Optimize an fst in-place in the log semiring.
     Args:
@@ -30,3 +31,4 @@ def optimize_in_log(fst: VectorFst):
     ret_code = lib.fst_optimize_in_log(ctypes.byref(fst.ptr))
     err_msg = "Error during optimize_in_log"
     check_ffi_error(ret_code, err_msg)
+    return fst

--- a/rustfst-python/rustfst/algorithms/rm_epsilon.py
+++ b/rustfst-python/rustfst/algorithms/rm_epsilon.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import ctypes
 from rustfst.ffi_utils import (
     lib,
     check_ffi_error,
@@ -10,16 +9,15 @@ from rustfst.fst.vector_fst import VectorFst
 
 def rm_epsilon(fst: VectorFst) -> VectorFst:
     """
-    Return an equivalent FST with epsilon transitions removed.
+    Remove epsilon transitions in-place
     Args:
-      fst: Fst
+      fst: Fst to remove epsilons from
     Returns:
-      Newly created FST with epsilon transitions removed.
+      fst: Same FST, modified in place
     """
 
-    rm_epsilon_fst = ctypes.c_void_p()
-    ret_code = lib.fst_rm_epsilon(fst.ptr, ctypes.byref(rm_epsilon_fst))
+    ret_code = lib.fst_rm_epsilon(fst.ptr)
     err_msg = "Error during rm_epsilon"
     check_ffi_error(ret_code, err_msg)
 
-    return VectorFst(ptr=rm_epsilon_fst)
+    return fst

--- a/rustfst-python/rustfst/algorithms/tr_sort.py
+++ b/rustfst-python/rustfst/algorithms/tr_sort.py
@@ -8,7 +8,7 @@ from rustfst.ffi_utils import (
 from rustfst.fst.vector_fst import VectorFst
 
 
-def tr_sort(fst: VectorFst, ilabel_cmp: bool):
+def tr_sort(fst: VectorFst, ilabel_cmp: bool) -> VectorFst:
     """
     tr_sort(fst)
     sort fst trs according to their ilabel or olabel
@@ -19,3 +19,4 @@ def tr_sort(fst: VectorFst, ilabel_cmp: bool):
     ret_code = lib.fst_tr_sort(fst.ptr, ctypes.c_bool(ilabel_cmp))
     err_msg = "Error during tr_sort"
     check_ffi_error(ret_code, err_msg)
+    return fst

--- a/rustfst-python/rustfst/algorithms/tr_sort.py
+++ b/rustfst-python/rustfst/algorithms/tr_sort.py
@@ -9,11 +9,18 @@ from rustfst.fst.vector_fst import VectorFst
 
 
 def tr_sort(fst: VectorFst, ilabel_cmp: bool) -> VectorFst:
-    """
-    tr_sort(fst)
-    sort fst trs according to their ilabel or olabel
-    :param fst: Fst
-    :param ilabel_cmp: bool
+    """Sort trs for an FST in-place according to their input or
+    output label.
+
+    This is often necessary for composition to work properly.  It
+    corresponds to `ArcSort` in OpenFST.
+
+    Args:
+      fst: FST to be tr-sorted in-place.
+      ilabel_cmp: Sort on input labels if `True`, output labels
+                 if `False`.
+    Returns:
+      fst: Same FST that was modified in-place.
     """
 
     ret_code = lib.fst_tr_sort(fst.ptr, ctypes.c_bool(ilabel_cmp))

--- a/rustfst-python/rustfst/algorithms/tr_unique.py
+++ b/rustfst-python/rustfst/algorithms/tr_unique.py
@@ -9,10 +9,14 @@ from rustfst.fst.vector_fst import VectorFst
 
 def tr_unique(fst: VectorFst) -> VectorFst:
     """
-    Keep a single instance of trs leaving the same state, going to the same state and
-    with the same input labels, output labels and weight.
+    Modify an FST in-place, keeping a single instance of trs
+    leaving the same state, going to the same state and with the same
+    input labels, output labels and weight.
+
     Args:
         fst: Fst to modify
+    Returns:
+        fst: Same FST, modified in-place
     """
 
     ret_code = lib.fst_tr_unique(fst.ptr)

--- a/rustfst-python/rustfst/algorithms/tr_unique.py
+++ b/rustfst-python/rustfst/algorithms/tr_unique.py
@@ -7,7 +7,7 @@ from rustfst.ffi_utils import (
 from rustfst.fst.vector_fst import VectorFst
 
 
-def tr_unique(fst: VectorFst):
+def tr_unique(fst: VectorFst) -> VectorFst:
     """
     Keep a single instance of trs leaving the same state, going to the same state and
     with the same input labels, output labels and weight.
@@ -18,3 +18,4 @@ def tr_unique(fst: VectorFst):
     ret_code = lib.fst_tr_unique(fst.ptr)
     err_msg = "Error during tr_unique"
     check_ffi_error(ret_code, err_msg)
+    return fst

--- a/rustfst-python/rustfst/fst/vector_fst.py
+++ b/rustfst-python/rustfst/fst/vector_fst.py
@@ -609,9 +609,9 @@ class VectorFst(Fst):
 
     def rm_epsilon(self) -> VectorFst:
         """
-        Return an equivalent FST with epsilon transitions removed.
+        Remove epsilon transitions in-place.
         Returns:
-          Newly created FST with epsilon transitions removed.
+          self: Same FST, modified in place
         """
         from rustfst.algorithms.rm_epsilon import rm_epsilon
 

--- a/rustfst-python/rustfst/fst/vector_fst.py
+++ b/rustfst-python/rustfst/fst/vector_fst.py
@@ -673,8 +673,7 @@ class VectorFst(Fst):
         """
         from rustfst.algorithms.optimize import optimize
 
-        optimize(self)
-        return self
+        return optimize(self)
 
     def optimize_in_log(self) -> VectorFst:
         """
@@ -684,10 +683,9 @@ class VectorFst(Fst):
         """
         from rustfst.algorithms.optimize import optimize_in_log
 
-        optimize_in_log(self)
-        return self
+        return optimize_in_log(self)
 
-    def tr_sort(self, ilabel_cmp: bool = True):
+    def tr_sort(self, ilabel_cmp: bool = True) -> VectorFst:
         """Sort trs for an FST in-place according to their input or
         output label.
 
@@ -697,19 +695,24 @@ class VectorFst(Fst):
         Args:
           ilabel_cmp: Sort on input labels if `True`, output labels
                       if `False`.
+        Returns:
+          self
         """
         from rustfst.algorithms.tr_sort import tr_sort
 
-        tr_sort(self, ilabel_cmp)
+        return tr_sort(self, ilabel_cmp)
 
-    def tr_unique(self):
+    def tr_unique(self) -> VectorFst:
         """Modify an FST in-place, keeping a single instance of trs
         leaving the same state, going to the same state and with the
         same input labels, output labels and weight.
+
+        Returns:
+          self
         """
         from rustfst.algorithms.tr_unique import tr_unique
 
-        tr_unique(self)
+        return tr_unique(self)
 
     def isomorphic(self, other: VectorFst) -> bool:
         """

--- a/rustfst-python/tests/algorithms/test_rm_epsilon.py
+++ b/rustfst-python/tests/algorithms/test_rm_epsilon.py
@@ -47,6 +47,7 @@ def test_rm_epsilon():
     tr1_2 = Tr(1, 0, 3.0, s2)
     expected_fst.add_tr(s1, tr1_2)
 
-    fst1.rm_epsilon()
+    rv = fst1.rm_epsilon()
+    assert rv == fst1
 
     assert expected_fst == fst1


### PR DESCRIPTION
Fixes #279 

Also fix the quite bogus code in `rustfst.algorithms.rm_epsilon` which called the underlying function with an extra (bogus) argument and returned a mysterious (bogus) pointer.