### PR TITLE
Implement `WeaklyDivisibleSemiring` for `BooleanWeight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Binary serialization & deserialization support for FST caches.
 - Binary serialization & deserialization support for Compose FST op state table.
+- Implement `WeaklyDivisibleSemiring` for `BooleanWeight`
 
 ## [0.8.0] - 2020-16-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustfst"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-cli"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "rustfst-ffi"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "downcast-rs",

--- a/rustfst/src/semirings/boolean_weight.rs
+++ b/rustfst/src/semirings/boolean_weight.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 
 use crate::semirings::{CompleteSemiring, ReverseBack, Semiring, SemiringProperties, StarSemiring};
 use std::borrow::Borrow;
+
+use super::{DivideType, WeaklyDivisibleSemiring};
 /// Boolean semiring: (&, |, false, true).
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Eq, Copy, Hash)]
 pub struct BooleanWeight {
@@ -74,6 +76,15 @@ impl CompleteSemiring for BooleanWeight {}
 impl StarSemiring for BooleanWeight {
     fn closure(&self) -> Self {
         Self::new(true)
+    }
+}
+
+impl WeaklyDivisibleSemiring for BooleanWeight {
+    fn divide_assign(&mut self, rhs: &Self, _divide_type: DivideType) -> Result<()> {
+        if !rhs.value {
+            bail!("Division by 0")
+        }
+        Ok(()) // x / true == true
     }
 }
 


### PR DESCRIPTION
According to the definition in [the docs for `WeaklyDivisibleSemiring`](https://docs.rs/rustfst/1.1.2/rustfst/semirings/trait.WeaklyDivisibleSemiring.html), `BooleanWeight` (`S = bool`, `+ = |`, `* = &`, `0 = false`, `1 = true`) should be weakly divisible: there are three combinations `(x, y)` such that `x + y != 0`:

* `x = true`, `y = true`: in this case, we can set `z = true` so that `true = (true | true) & true`.
* `x = true`, `y = false`: we can set `z = true` so that `true = (true | false) & true`.
* `x = false`, `y = true`: we can set `z = false` so that `false = (false | true) & false`.

In fact, `BooleanWeight` is divisible because the inverse of `true` is `true`.

This PR adds an implementation of `WeaklyDivisibleSemiring` for `BooleanWeight`.